### PR TITLE
Dealing with non-picklable objects

### DIFF
--- a/src/soorgeon/cli.py
+++ b/src/soorgeon/cli.py
@@ -33,7 +33,13 @@ def cli():
     type=click.Choice(('py', 'ipynb')),
     help=('Format for pipeline tasks, if empty keeps the same format '
           'as the input'))
-def refactor(path, log, product_prefix, df_format, single_task, file_format):
+@click.option(
+    '--serializer',
+    '-z',
+    default=None,
+    type=click.Choice(('cloudpickle')),
+    help='Serializer for non-picklable data')
+def refactor(path, log, product_prefix, df_format, single_task, file_format, serializer):
     """
     Refactor a monolithic notebook.
 
@@ -47,12 +53,14 @@ def refactor(path, log, product_prefix, df_format, single_task, file_format):
 
     User guide: https://github.com/ploomber/soorgeon/blob/main/doc/guide.md
     """
+    print("inside refactor")
     export.refactor(path,
                     log,
                     product_prefix=product_prefix,
                     df_format=df_format,
                     single_task=single_task,
-                    file_format=file_format)
+                    file_format=file_format,
+                    serializer=serializer)
 
     click.secho(f'Finished refactoring {path!r}, use Ploomber to continue.',
                 fg='green')

--- a/src/soorgeon/cli.py
+++ b/src/soorgeon/cli.py
@@ -33,13 +33,13 @@ def cli():
     type=click.Choice(('py', 'ipynb')),
     help=('Format for pipeline tasks, if empty keeps the same format '
           'as the input'))
-@click.option(
-    '--serializer',
-    '-z',
-    default=None,
-    type=click.Choice(('cloudpickle', 'dill')),
-    help='Serializer for non-picklable data')
-def refactor(path, log, product_prefix, df_format, single_task, file_format, serializer):
+@click.option('--serializer',
+              '-z',
+              default=None,
+              type=click.Choice(('cloudpickle', 'dill')),
+              help='Serializer for non-picklable data')
+def refactor(path, log, product_prefix, df_format, single_task, file_format,
+             serializer):
     """
     Refactor a monolithic notebook.
 
@@ -62,7 +62,7 @@ def refactor(path, log, product_prefix, df_format, single_task, file_format, ser
                     file_format=file_format,
                     serializer=serializer)
 
-    click.secho(f'Finished new refactoring {path!r}, use Ploomber to continue.',
+    click.secho(f'Finished refactoring {path!r}, use Ploomber to continue.',
                 fg='green')
 
     click.echo("""

--- a/src/soorgeon/cli.py
+++ b/src/soorgeon/cli.py
@@ -37,7 +37,7 @@ def cli():
     '--serializer',
     '-z',
     default=None,
-    type=click.Choice(('cloudpickle')),
+    type=click.Choice(('cloudpickle', 'dill')),
     help='Serializer for non-picklable data')
 def refactor(path, log, product_prefix, df_format, single_task, file_format, serializer):
     """
@@ -53,7 +53,7 @@ def refactor(path, log, product_prefix, df_format, single_task, file_format, ser
 
     User guide: https://github.com/ploomber/soorgeon/blob/main/doc/guide.md
     """
-    print("inside refactor")
+
     export.refactor(path,
                     log,
                     product_prefix=product_prefix,
@@ -62,7 +62,7 @@ def refactor(path, log, product_prefix, df_format, single_task, file_format, ser
                     file_format=file_format,
                     serializer=serializer)
 
-    click.secho(f'Finished refactoring {path!r}, use Ploomber to continue.',
+    click.secho(f'Finished new refactoring {path!r}, use Ploomber to continue.',
                 fg='green')
 
     click.echo("""

--- a/src/soorgeon/export.py
+++ b/src/soorgeon/export.py
@@ -150,6 +150,11 @@ class NotebookExporter:
                              "None, 'parquet' or 'csv', "
                              f"got: {df_format!r}")
 
+        if serializer not in {None, 'cloudpickle', 'dill'}:
+            raise ValueError("serializer must be one of "
+                             "None, 'cloudpickle' or 'dill', "
+                             f"got: {serializer!r}")
+
         # NOTE: we're commenting magics here but removing them in ProtoTask,
         # maybe we should comment magics also in ProtoTask?
         nb = magics.comment_magics(nb)

--- a/src/soorgeon/export.py
+++ b/src/soorgeon/export.py
@@ -144,7 +144,13 @@ pp = pprint.PrettyPrinter(indent=4)
 class NotebookExporter:
     """Converts a notebook into a Ploomber pipeline
     """
-    def __init__(self, nb, verbose=True, df_format=None, serializer=None, py=False):
+
+    def __init__(self,
+                 nb,
+                 verbose=True,
+                 df_format=None,
+                 serializer=None,
+                 py=False):
         if df_format not in {None, 'parquet', 'csv'}:
             raise ValueError("df_format must be one of "
                              "None, 'parquet' or 'csv', "
@@ -314,11 +320,9 @@ class NotebookExporter:
             pkgs = ['pyarrow'] + pkgs
 
         # add cloudpickle/dill to requirements if needed
-        if (self._serializer == 'cloudpickle' and 'cloudpickle'
-                not in pkgs):
+        if (self._serializer == 'cloudpickle' and 'cloudpickle' not in pkgs):
             pkgs = ['cloudpickle'] + pkgs
-        elif (self._serializer == 'dill' and 'dill'
-                not in pkgs):
+        elif (self._serializer == 'dill' and 'dill' not in pkgs):
             pkgs = ['dill'] + pkgs
 
         pkgs_txt = '\n'.join(sorted(pkgs))
@@ -479,7 +483,12 @@ def _check_functions_do_not_use_global_variables(code):
         raise exceptions.InputError(message)
 
 
-def from_nb(nb, log=None, product_prefix=None, df_format=None, serializer=None, py=False):
+def from_nb(nb,
+            log=None,
+            product_prefix=None,
+            df_format=None,
+            serializer=None,
+            py=False):
     """Refactor a notebook by passing a notebook object
 
     Parameters
@@ -491,7 +500,10 @@ def from_nb(nb, log=None, product_prefix=None, df_format=None, serializer=None, 
     if log:
         logging.basicConfig(level=log.upper())
 
-    exporter = NotebookExporter(nb, df_format=df_format, serializer=serializer, py=py)
+    exporter = NotebookExporter(nb,
+                                df_format=df_format,
+                                serializer=serializer,
+                                py=py)
 
     exporter.export(product_prefix=product_prefix)
 
@@ -562,9 +574,8 @@ def single_task_from_path(path, product_prefix, file_format):
     Path('pipeline.yaml').write_text(yaml.safe_dump(spec, sort_keys=False))
 
 
-def refactor(path, log, product_prefix, df_format, single_task, file_format, serializer):
-
-    print('Refactoring code')
+def refactor(path, log, product_prefix, df_format, single_task, file_format,
+             serializer):
 
     if single_task:
         single_task_from_path(path=path,

--- a/src/soorgeon/export.py
+++ b/src/soorgeon/export.py
@@ -308,6 +308,14 @@ class NotebookExporter:
                 and 'fastparquet' not in pkgs):
             pkgs = ['pyarrow'] + pkgs
 
+        # add cloudpickle/dill to requirements if needed
+        if (self._serializer == 'cloudpickle' and 'cloudpickle'
+                not in pkgs):
+            pkgs = ['cloudpickle'] + pkgs
+        elif (self._serializer == 'dill' and 'dill'
+                not in pkgs):
+            pkgs = ['dill'] + pkgs
+
         pkgs_txt = '\n'.join(sorted(pkgs))
 
         out = f"""\

--- a/src/soorgeon/proto.py
+++ b/src/soorgeon/proto.py
@@ -25,6 +25,7 @@ Path(product['{{product}}']).write_bytes(dill.dumps({{product}}))
 Path(product['{{product}}']).parent.mkdir(exist_ok=True, parents=True)
 Path(product['{{product}}']).write_bytes(pickle.dumps({{product}}))
 {%- endif %}
+
 {% endfor -%}\
 """)
 

--- a/src/soorgeon/proto.py
+++ b/src/soorgeon/proto.py
@@ -52,12 +52,13 @@ def _new_pickling_cell(outputs, df_format, serializer):
     return nbformat.v4.new_code_cell(source=source)
 
 
-def _new_unpickling_cell(up_and_in, df_format):
+def _new_unpickling_cell(up_and_in, df_format, serializer):
     df_format = df_format or ''
     source = _UNPICKLING_TEMPLATE.render(up_and_in=sorted(up_and_in,
                                                           key=lambda t:
                                                           (t[0], t[1])),
-                                         df_format=df_format).strip()
+                                         df_format=df_format,
+                                         serializer=serializer).strip()
     return nbformat.v4.new_code_cell(source=source)
 
 
@@ -108,7 +109,7 @@ class ProtoTask:
             up_and_in = [(providers.get(input_, self.name), input_)
                          for input_ in inputs]
 
-            unpickling = _new_unpickling_cell(up_and_in, self._df_format)
+            unpickling = _new_unpickling_cell(up_and_in, self._df_format, self._serializer)
             unpickling.metadata['tags'] = ['soorgeon-unpickle']
 
             return unpickling

--- a/src/soorgeon/proto.py
+++ b/src/soorgeon/proto.py
@@ -28,7 +28,6 @@ Path(product['{{product}}']).write_bytes(pickle.dumps({{product}}))
 {% endfor -%}\
 """)
 
-
 _UNPICKLING_TEMPLATE = Template("""\
 {%- for up, key in up_and_in -%}
 {%- if key.startswith('df') and df_format in ('parquet', 'csv') -%}
@@ -93,7 +92,8 @@ class ProtoTask:
         _, outputs = io[self.name]
 
         if outputs:
-            pickling = _new_pickling_cell(outputs, self._df_format, self._serializer)
+            pickling = _new_pickling_cell(outputs, self._df_format,
+                                          self._serializer)
             pickling.metadata['tags'] = ['soorgeon-pickle']
 
             return pickling
@@ -109,7 +109,8 @@ class ProtoTask:
             up_and_in = [(providers.get(input_, self.name), input_)
                          for input_ in inputs]
 
-            unpickling = _new_unpickling_cell(up_and_in, self._df_format, self._serializer)
+            unpickling = _new_unpickling_cell(up_and_in, self._df_format,
+                                              self._serializer)
             unpickling.metadata['tags'] = ['soorgeon-unpickle']
 
             return unpickling

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -168,6 +168,17 @@ df_2 = df + 1
 
 """
 
+with_lambda = """\
+# ## first
+
+num_square = lambda n: n**2
+
+# ## second
+
+num_square = num_square(2)
+
+"""
+
 
 @pytest.mark.parametrize('args, requirements', [
     [['nb.py', '--serializer', 'cloudpickle'], 'cloudpickle\nploomber>=0.14.7'
@@ -184,10 +195,15 @@ df_2 = df + 1
             'output/second.ipynb',
         ]
     ],
+    [
+        with_lambda,
+        [
+            'output/first-num_square.pkl', 'output/first.ipynb',
+            'output/second.ipynb', 'output/second-num_square.pkl'
+        ]
+    ],
 ],
-                         ids=[
-                             'with-dfs',
-                         ])
+                         ids=['with-dfs', 'with-lambda'])
 def test_refactor_serializer(tmp_empty, args, nb, products_expected,
                              requirements):
     Path('nb.py').write_text(nb)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,6 +157,64 @@ def test_refactor_df_format(tmp_empty, args, ext, nb, products_expected,
     assert Path('requirements.txt').read_text() == content
 
 
+with_dfs = """\
+# ## first
+
+df = 1
+
+# ## second
+
+df_2 = df + 1
+
+"""
+
+
+@pytest.mark.parametrize('args, requirements', [
+    [['nb.py', '--serializer', 'cloudpickle'], 'cloudpickle\nploomber>=0.14.7'],
+    [['nb.py', '--serializer', 'dill'], 'dill\nploomber>=0.14.7'],
+],
+                         ids=[
+                             'cloudpickle',
+                             'dill'
+                         ])
+@pytest.mark.parametrize('nb, products_expected', [
+
+    [
+        with_dfs,
+        [
+            'output/first-df.pkl',
+            'output/first.ipynb',
+            'output/second.ipynb',
+        ]
+    ],
+
+],
+                         ids=[
+
+                             'with-dfs',
+
+                         ])
+def test_refactor_serializer(tmp_empty, args, nb, products_expected,
+                            requirements):
+    Path('nb.py').write_text(nb)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.refactor, args)
+
+    spec = DAGSpec('pipeline.yaml')
+
+    paths = [
+        i for product in [t['product'].values() for t in spec['tasks']]
+        for i in product
+    ]
+    assert set(paths) == set(products_expected)
+    assert result.exit_code == 0
+
+    content = ('# Auto-generated file'
+               f', may need manual editing\n{requirements}\n')
+    assert Path('requirements.txt').read_text() == content
+
+
 imports_pyarrow = """\
 # ## first
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -170,15 +170,12 @@ df_2 = df + 1
 
 
 @pytest.mark.parametrize('args, requirements', [
-    [['nb.py', '--serializer', 'cloudpickle'], 'cloudpickle\nploomber>=0.14.7'],
+    [['nb.py', '--serializer', 'cloudpickle'], 'cloudpickle\nploomber>=0.14.7'
+     ],
     [['nb.py', '--serializer', 'dill'], 'dill\nploomber>=0.14.7'],
 ],
-                         ids=[
-                             'cloudpickle',
-                             'dill'
-                         ])
+                         ids=['cloudpickle', 'dill'])
 @pytest.mark.parametrize('nb, products_expected', [
-
     [
         with_dfs,
         [
@@ -187,15 +184,12 @@ df_2 = df + 1
             'output/second.ipynb',
         ]
     ],
-
 ],
                          ids=[
-
                              'with-dfs',
-
                          ])
 def test_refactor_serializer(tmp_empty, args, nb, products_expected,
-                            requirements):
+                             requirements):
     Path('nb.py').write_text(nb)
 
     runner = CliRunner()

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -231,6 +231,7 @@ def test_from_nb(tmp_empty, nb_str, tasks):
     dag.build()
     assert list(dag) == tasks
 
+
 eda = """# # Some analysis
 #
 # ## Load
@@ -247,12 +248,12 @@ df = df(10)
 
 sns.histplot(df)
 """
+
+
 @pytest.mark.parametrize('nb_str, tasks', [
     [eda, ['load', 'clean', 'plot']],
 ],
-                         ids=[
-                             'eda'
-                         ])
+                         ids=['eda'])
 def test_from_nb_unpicklable(tmp_empty, nb_str, tasks):
     export.from_nb(_read(nb_str), py=True)
 
@@ -260,8 +261,6 @@ def test_from_nb_unpicklable(tmp_empty, nb_str, tasks):
 
     dag.build()
     assert list(dag) == tasks
-
-
 
 
 @pytest.mark.parametrize('py, ext', [
@@ -806,15 +805,14 @@ dill_unpickling = """\
 x = dill.loads(Path(upstream[\'first\'][\'x\']).read_bytes())\
 """
 
-@pytest.mark.parametrize('serializer, pickling, unpickling', [
-    ['cloudpickle', cloudpickle_pickling, cloudpickle_unpickling],
-    ['dill', dill_pickling, dill_unpickling]
-],
-                         ids=[
-                             'cloudpickle',
-                             'dill'
-                         ])
-def test_prototask_un_pickling_cells_with_serializer(serializer, pickling, unpickling):
+
+@pytest.mark.parametrize(
+    'serializer, pickling, unpickling',
+    [['cloudpickle', cloudpickle_pickling, cloudpickle_unpickling],
+     ['dill', dill_pickling, dill_unpickling]],
+    ids=['cloudpickle', 'dill'])
+def test_prototask_un_pickling_cells_with_serializer(serializer, pickling,
+                                                     unpickling):
     code = """\
 # ## first
 
@@ -831,7 +829,7 @@ x = x + 2
     one, two = exporter._proto_tasks
 
     assert one._pickling_cell(exporter.io)['source'] == pickling
-    assert two._pickling_cell(exporter.io) ['source'] == pickling
+    assert two._pickling_cell(exporter.io)['source'] == pickling
 
     assert one._unpickling_cell(exporter.io, exporter.providers) is None
     assert two._unpickling_cell(exporter.io,
@@ -844,11 +842,13 @@ def test_validates_df_format():
 
     assert 'df_format must be one of ' in str(excinfo.value)
 
+
 def test_validates_serializer():
     with pytest.raises(ValueError) as excinfo:
         export.NotebookExporter(_read(''), serializer='something')
 
     assert 'serializer must be one of ' in str(excinfo.value)
+
 
 def test_creates_readme(tmp_empty):
     exporter = export.NotebookExporter(_read(simple))
@@ -865,4 +865,3 @@ def test_appends_to_readme(tmp_empty):
 
     expected = '# Some stuff\n' + resources.read_text(assets, 'README.md')
     assert Path('README.md').read_text() == expected
-

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -231,6 +231,38 @@ def test_from_nb(tmp_empty, nb_str, tasks):
     dag.build()
     assert list(dag) == tasks
 
+eda = """# # Some analysis
+#
+# ## Load
+
+import seaborn as sns
+
+df = lambda x: list(range(x))
+
+# ## Clean
+
+df = df(10)
+
+# ## Plot
+
+sns.histplot(df)
+"""
+@pytest.mark.parametrize('nb_str, tasks', [
+    [eda, ['load', 'clean', 'plot']],
+],
+                         ids=[
+                             'eda'
+                         ])
+def test_from_nb_unpicklable(tmp_empty, nb_str, tasks):
+    export.from_nb(_read(nb_str), py=True)
+
+    dag = DAGSpec('pipeline.yaml').to_dag()
+
+    dag.build()
+    assert list(dag) == tasks
+
+
+
 
 @pytest.mark.parametrize('py, ext', [
     [True, 'py'],

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -232,37 +232,6 @@ def test_from_nb(tmp_empty, nb_str, tasks):
     assert list(dag) == tasks
 
 
-eda = """# # Some analysis
-#
-# ## Load
-
-import seaborn as sns
-
-df = lambda x: list(range(x))
-
-# ## Clean
-
-df = df(10)
-
-# ## Plot
-
-sns.histplot(df)
-"""
-
-
-@pytest.mark.parametrize('nb_str, tasks', [
-    [eda, ['load', 'clean', 'plot']],
-],
-                         ids=['eda'])
-def test_from_nb_unpicklable(tmp_empty, nb_str, tasks):
-    export.from_nb(_read(nb_str), py=True)
-
-    dag = DAGSpec('pipeline.yaml').to_dag()
-
-    dag.build()
-    assert list(dag) == tasks
-
-
 @pytest.mark.parametrize('py, ext', [
     [True, 'py'],
     [False, 'ipynb'],

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -757,21 +757,21 @@ df_2 = x + df + 1
 
 
 cloudpickle_pickling = """\
-Path(product[\'x\']).parent.mkdir(exist_ok=True, parents=True)
-Path(product[\'x\']).write_bytes(cloudpickle.dumps(x))\
+Path(product['x']).parent.mkdir(exist_ok=True, parents=True)
+Path(product['x']).write_bytes(cloudpickle.dumps(x))\
 """
 
 cloudpickle_unpickling = """\
-x = cloudpickle.loads(Path(upstream[\'first\'][\'x\']).read_bytes())\
+x = cloudpickle.loads(Path(upstream['first']['x']).read_bytes())\
 """
 
 dill_pickling = """\
-Path(product[\'x\']).parent.mkdir(exist_ok=True, parents=True)
-Path(product[\'x\']).write_bytes(dill.dumps(x))\
+Path(product['x']).parent.mkdir(exist_ok=True, parents=True)
+Path(product['x']).write_bytes(dill.dumps(x))\
 """
 
 dill_unpickling = """\
-x = dill.loads(Path(upstream[\'first\'][\'x\']).read_bytes())\
+x = dill.loads(Path(upstream['first']['x']).read_bytes())\
 """
 
 

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -14,7 +14,10 @@ mixed_expected = '1 + 1 # Cell 1\n2 + 2 # Cell 3'
 ])
 def test_prototask_str(code, expected):
     assert str(
-        proto.ProtoTask('name', _read(code).cells, df_format=None, serializer=None,
+        proto.ProtoTask('name',
+                        _read(code).cells,
+                        df_format=None,
+                        serializer=None,
                         py=True)) == expected
 
 
@@ -24,7 +27,11 @@ def test_prototask_str(code, expected):
 def test_prototask_add_imports_cell(cells_idx, expected):
     cells = jupytext.reads(exploratory,
                            fmt='py:light').cells[cells_idx[0]:cells_idx[1]]
-    pt = proto.ProtoTask('task', cells, df_format=None, serializer=None, py=True)
+    pt = proto.ProtoTask('task',
+                         cells,
+                         df_format=None,
+                         serializer=None,
+                         py=True)
     cell = pt._add_imports_cell(exploratory,
                                 add_pathlib_and_pickle=False,
                                 definitions=None,

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -14,7 +14,7 @@ mixed_expected = '1 + 1 # Cell 1\n2 + 2 # Cell 3'
 ])
 def test_prototask_str(code, expected):
     assert str(
-        proto.ProtoTask('name', _read(code).cells, df_format=None,
+        proto.ProtoTask('name', _read(code).cells, df_format=None, serializer=None,
                         py=True)) == expected
 
 
@@ -24,9 +24,10 @@ def test_prototask_str(code, expected):
 def test_prototask_add_imports_cell(cells_idx, expected):
     cells = jupytext.reads(exploratory,
                            fmt='py:light').cells[cells_idx[0]:cells_idx[1]]
-    pt = proto.ProtoTask('task', cells, df_format=None, py=True)
+    pt = proto.ProtoTask('task', cells, df_format=None, serializer=None, py=True)
     cell = pt._add_imports_cell(exploratory,
                                 add_pathlib_and_pickle=False,
                                 definitions=None,
-                                df_format=None)
+                                df_format=None,
+                                serializer=None)
     assert cell['source'] == expected


### PR DESCRIPTION
The PR tries to solve https://github.com/ploomber/soorgeon/issues/9
1. Added a CLI option called serializer which can be one of cloudpickle or dill
2. Based on the serializer selected soorgeon will try to pickle the objects with either cloudpickle or dill
3. Both the packages are optional dependencies