### PR TITLE
Add errors for Only H1 headings

### DIFF
--- a/src/soorgeon/split.py
+++ b/src/soorgeon/split.py
@@ -90,33 +90,27 @@ def _sanitize_name(name):
     return sanitized
 
 
-def _get_h2_header(md):
-    lines = md.splitlines()
+def _get_header_factory(regex):
+    def _get_header(md):
+        # pass regex to re.search
+        lines = md.splitlines()
 
-    found = None
+        found = None
 
-    for line in lines:
-        match = re.search(r'^\s*##\s+(.+)', line)
+        for line in lines:
+            match = re.search(regex, line)
 
-        if match:
-            found = _sanitize_name(match.group(1))
+            if match:
+                found = _sanitize_name(match.group(1))
 
-            break
+                break
 
-    return found
+        return found
+
+    return _get_header
 
 
-def _get_h1_header(md):
-    lines = md.splitlines()
+_get_h1_header = _get_header_factory(r'^\s*#\s+(.+)')
 
-    found = None
 
-    for line in lines:
-        match = re.search(r'^\s*#\s+(.+)', line)
-
-        if match:
-            found = _sanitize_name(match.group(1))
-
-            break
-
-    return found
+_get_h2_header = _get_header_factory(r'^\s*##\s+(.+)')

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -29,17 +29,6 @@ all_h2 = """# ## Cell 0
 # ## Cell 4
 """
 
-all_h1 = """# # Cell 0
-
-1 + 1 # Cell 1
-
-# # Cell 2
-
-2 + 2 # Cell 3
-
-# # Cell 4
-"""
-
 long_md = """# ## H2
 # with more text here
 


### PR DESCRIPTION
## Describe your changes
* Add errors for Only H1 headings:
  * Logic:
      * No H2 headers:
          * Only H1 headers: `Only H1 headings are found. At this time, only H2 heading are supported.`
          * No H1 and H2 headers: `Expected notebook to have at least one markdown H2 heading.`
      * Only one H2 header: Warning: `refactoring successful but only one H2 heading detected...`
      * Otherwise: run smoothly
* Add a new test case for `_get_h2_header` (`###`->None), and a new method `_get_h1_header` along with tests
* Update test `test_find_breaks_error_if_no_h2_headers` to `test_find_breaks_error_if_no_h2_but_h1_headers` and `test_find_breaks_error_if_no_h1_and_h2_headers`

## Issue ticket number and link
Closes #5 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.
 - Update: Fixed the issue of matching H3 or smaller headers as H2. Add error messages when there are only H1 headers.