### PR TITLE
Add compatible python version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Try the interactive demo:
 
 ## Install
 
+*Compatible with Python 3.7 and higher.*
+
 ```sh
 pip install soorgeon
 ```


### PR DESCRIPTION
I looked through the code and there aren't any explicit mentions of older versions of python so I added a message in the readme that states the versions of python supported by soorgeon

## Issue ticket number and link
Closes #69 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.
