### PR TITLE
Remove isort and update black to remove temp file creation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ To learn more, check out our [guide](doc/guide.md).
 ### Cleaning
 
 Soorgeon has a `clean` command that applies
-[black](https://github.com/psf/black) and
-[isort](https://github.com/PyCQA/isort) for `.ipynb` and `.py` files:
+[black](https://github.com/psf/black) <!--and [isort](https://github.com/PyCQA/isort)-->for `.ipynb` and `.py` files:
 
 ```
 soorgeon clean path/to/notebook.ipynb
@@ -107,7 +106,7 @@ soorgeon clean path/to/script.py
 
 ## Linting
 
-Soorgeon has a `clean` command that can apply [flake8]:
+Soorgeon has a `lint` command that can apply [flake8]:
 
 ```
 soorgeon lint path/to/notebook.ipynb

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ REQUIRES = [
     'isort',
     # for checking code errors
     'pyflakes',
-    "black[jupyter]"
+    "black[jupyter]>=22.6.0"
 ]
 
 DEV = [

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ REQUIRES = [
     'isort',
     # for checking code errors
     'pyflakes',
-    "black"
+    "black[jupyter]"
 ]
 
 DEV = [

--- a/src/soorgeon/clean.py
+++ b/src/soorgeon/clean.py
@@ -36,9 +36,8 @@ def basic_clean(task_file, program="black"):
     Run basic clean (directly called by cli.clean())
     Generate intermediate files for ipynb
     """
-
     # temp_file=False for clean operations that are the same for py and ipynb
-    with get_file(task_file, write=True, temp_file=False) as path:
+    with get_file(task_file, write=True) as path:
         clean_py(path, task_file)
 
     click.echo(f"Finished cleaning {task_file}")
@@ -66,14 +65,10 @@ def run_program(task_file_py, program, filename):
 
 
 @contextmanager
-def get_file(task_file, write=False, temp_file=True):
-    '''
-    When temp_file is True, create temp py file for ipynb files
-    '''
+def get_file(task_file, write=False):
     task_file = Path(task_file)
-    if not temp_file:
-        return
-    create_temp = task_file.suffix != ".py"
+    # only works for black
+    create_temp = task_file.suffix == ".md"
     text = task_file.read_text()
 
     if create_temp:

--- a/src/soorgeon/clean.py
+++ b/src/soorgeon/clean.py
@@ -45,7 +45,10 @@ def basic_clean(task_file, program="black"):
 
 def clean_py(task_file_py, filename):
     # reformat with black
-    black_result = format_file_in_place(task_file_py, fast=True, mode=FileMode(), write_back=WriteBack(1))
+    black_result = format_file_in_place(task_file_py,
+                                        fast=True,
+                                        mode=FileMode(),
+                                        write_back=WriteBack(1))
     if black_result:
         click.echo(f"Reformatted {filename} with black.")
 

--- a/src/soorgeon/clean.py
+++ b/src/soorgeon/clean.py
@@ -1,6 +1,7 @@
 import shutil
 import subprocess
 import tempfile
+from black import format_file_in_place, FileMode, WriteBack
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -43,7 +44,10 @@ def basic_clean(task_file, program="black"):
 
 
 def clean_py(task_file_py, filename):
-    run_program(task_file_py, program="black", filename=filename)
+    # reformat with black
+    black_result = format_file_in_place(task_file_py, fast=True, mode=FileMode(), write_back=WriteBack(1))
+    if black_result:
+        click.echo(f"Reformatted {filename} with black.")
 
 
 def run_program(task_file_py, program, filename):

--- a/src/soorgeon/clean.py
+++ b/src/soorgeon/clean.py
@@ -36,7 +36,6 @@ def basic_clean(task_file, program="black"):
     Run basic clean (directly called by cli.clean())
     Generate intermediate files for ipynb
     """
-    # temp_file=False for clean operations that are the same for py and ipynb
     with get_file(task_file, write=True) as path:
         clean_py(path, task_file)
 

--- a/src/soorgeon/clean.py
+++ b/src/soorgeon/clean.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import click
-import isort
 import jupytext
 
 from soorgeon.exceptions import BaseException
@@ -37,7 +36,9 @@ def basic_clean(task_file, program="black"):
     Run basic clean (directly called by cli.clean())
     Generate intermediate files for ipynb
     """
-    with get_file(task_file, write=True) as path:
+
+    # temp_file=False for clean operations that are the same for py and ipynb
+    with get_file(task_file, write=True, temp_file=False) as path:
         clean_py(path, task_file)
 
     click.echo(f"Finished cleaning {task_file}")
@@ -45,7 +46,6 @@ def basic_clean(task_file, program="black"):
 
 def clean_py(task_file_py, filename):
     run_program(task_file_py, program="black", filename=filename)
-    isort.file(task_file_py)
 
 
 def run_program(task_file_py, program, filename):
@@ -66,8 +66,13 @@ def run_program(task_file_py, program, filename):
 
 
 @contextmanager
-def get_file(task_file, write=False):
+def get_file(task_file, write=False, temp_file=True):
+    '''
+    When temp_file is True, create temp py file for ipynb files
+    '''
     task_file = Path(task_file)
+    if not temp_file:
+        return
     create_temp = task_file.suffix != ".py"
     text = task_file.read_text()
 

--- a/src/soorgeon/clean.py
+++ b/src/soorgeon/clean.py
@@ -26,7 +26,7 @@ def _jupytext_fmt(text, extension):
 
 @telemetry.log_call('lint')
 def lint(task_file):
-    with get_file(task_file, write=False) as path:
+    with get_file(task_file, write=False, output_ext=".py") as path:
         run_program(path, program='flake8', filename=task_file)
 
 
@@ -64,15 +64,15 @@ def run_program(task_file_py, program, filename):
 
 
 @contextmanager
-def get_file(task_file, write=False):
+def get_file(task_file, write=False, output_ext=".ipynb"):
     task_file = Path(task_file)
     # only works for black
-    create_temp = task_file.suffix == ".md"
+    create_temp = task_file.suffix != output_ext
     text = task_file.read_text()
 
     if create_temp:
         nb = jupytext.reads(text)
-        temp_path = tempfile.NamedTemporaryFile(suffix=".py",
+        temp_path = tempfile.NamedTemporaryFile(suffix=output_ext,
                                                 delete=False).name
         jupytext.write(nb, temp_path)
         path = Path(temp_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -396,8 +396,6 @@ def test_clean_py(tmp_empty):
     assert result.exit_code == 0
     # black
     assert "1 file reformatted." in result.output
-    # # isort
-    # assert "Fixing" in result.output
     # end of basic_clean()
     assert "Finished cleaning tasks/cell-2.py" in result.output
 
@@ -413,8 +411,6 @@ def test_clean_ipynb(tmp_empty):
     assert result.exit_code == 0
     # black
     assert "1 file reformatted." in result.output
-    # # isort
-    # assert "Fixing" in result.output
     # end of basic_clean()
     assert "Finished cleaning tasks/cell-2.ipynb" in result.output
 
@@ -463,8 +459,6 @@ def test_clean_markdown(tmp_empty, content, fmt):
     assert result.exit_code == 0
     # black
     assert "1 file reformatted." in result.output
-    # # isort
-    # assert "Fixing" in result.output
     # end of basic_clean()
     assert "Finished cleaning file.md" in result.output
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -396,8 +396,8 @@ def test_clean_py(tmp_empty):
     assert result.exit_code == 0
     # black
     assert "1 file reformatted." in result.output
-    # isort
-    assert "Fixing" in result.output
+    # # isort
+    # assert "Fixing" in result.output
     # end of basic_clean()
     assert "Finished cleaning tasks/cell-2.py" in result.output
 
@@ -413,8 +413,8 @@ def test_clean_ipynb(tmp_empty):
     assert result.exit_code == 0
     # black
     assert "1 file reformatted." in result.output
-    # isort
-    assert "Fixing" in result.output
+    # # isort
+    # assert "Fixing" in result.output
     # end of basic_clean()
     assert "Finished cleaning tasks/cell-2.ipynb" in result.output
 
@@ -463,8 +463,8 @@ def test_clean_markdown(tmp_empty, content, fmt):
     assert result.exit_code == 0
     # black
     assert "1 file reformatted." in result.output
-    # isort
-    assert "Fixing" in result.output
+    # # isort
+    # assert "Fixing" in result.output
     # end of basic_clean()
     assert "Finished cleaning file.md" in result.output
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -395,7 +395,7 @@ def test_clean_py(tmp_empty):
     result = runner.invoke(cli.clean, ['tasks/cell-2.py'])
     assert result.exit_code == 0
     # black
-    assert "1 file reformatted." in result.output
+    assert "Reformatted tasks/cell-2.py with black" in result.output
     # end of basic_clean()
     assert "Finished cleaning tasks/cell-2.py" in result.output
 
@@ -410,7 +410,7 @@ def test_clean_ipynb(tmp_empty):
 
     assert result.exit_code == 0
     # black
-    assert "1 file reformatted." in result.output
+    assert "Reformatted tasks/cell-2.ipynb with black" in result.output
     # end of basic_clean()
     assert "Finished cleaning tasks/cell-2.ipynb" in result.output
 
@@ -458,7 +458,7 @@ def test_clean_markdown(tmp_empty, content, fmt):
 
     assert result.exit_code == 0
     # black
-    assert "1 file reformatted." in result.output
+    assert "Reformatted file.md with black." in result.output
     # end of basic_clean()
     assert "Finished cleaning file.md" in result.output
 


### PR DESCRIPTION
## Describe your changes
* Remove isort in the clean module.
* Update black to temporarily convert py and md files to ipynb format for reformatting instead, while keeping lint using the `ipynb->py` way.
* Update black to call `black.format_file_in_place` directly.
* Pin black version to `black[jupyter]>=22.6.0`.
* Fix a typo in README (`lint`).
## Issue ticket number and link
#81

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.
