### PR TITLE
Add papermill to required dependencies instead of development

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,8 @@ jobs:
           flake8
       - name: Install dependencies
         run: |
+          pip install .
+          python -c "import soorgeon"
           pip install ".[dev]"
       - name: Unit tests
         run: |

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ REQUIRES = [
     'isort',
     # for checking code errors
     'pyflakes',
-    "black[jupyter]>=22.6.0"
+    'black[jupyter]>=22.6.0',
+    'papermill'
 ]
 
 DEV = [
@@ -45,7 +46,6 @@ DEV = [
     'pandas',
     'scikit-learn',
     'seaborn',
-    'papermill',
     'pkgmt',
     'twine'
 ]


### PR DESCRIPTION
## Describe your changes
1. papermill is now a mandatory dependency & not a dev dependency. Usage of soorgeon fail without it.
2. GitHub workflows did not fail because it was installing dev dependencies before using soorgeon. 
3. Added papermill to required dependencies in `setup.py`
4. Removed papermill from dev dependencies in `setup.py`
5. In `.github/workflows/ci.yaml`, we now install required dependencies & import soorgeon before installation of dev dependencies to ensure this won't happen again.

## Issue ticket number and link
Closes #x 

## Checklist before requesting a review
- [ x] I have performed a self-review of my code
- [ ] I have added thorough tests (when necessary).
- [ ] I have added the right documentation (when needed). Product update? If yes, write one line about this update.
