### PR TITLE
Apply black before refactoring

### DIFF
--- a/src/soorgeon/clean.py
+++ b/src/soorgeon/clean.py
@@ -32,22 +32,24 @@ def lint(task_file):
 
 
 @telemetry.log_call('clean')
-def basic_clean(task_file, program="black"):
+def basic_clean(task_file, program="black", string_normalization=True):
     """
     Run basic clean (directly called by cli.clean())
     Generate intermediate files for ipynb
     """
     with get_file(task_file, write=True) as path:
-        clean_py(path, task_file)
+        clean_py(path, task_file, string_normalization=string_normalization)
 
     click.echo(f"Finished cleaning {task_file}")
 
 
-def clean_py(task_file_py, filename):
+def clean_py(task_file_py, filename, string_normalization=True):
+    mode = FileMode(string_normalization=string_normalization)
+
     # reformat with black
     black_result = format_file_in_place(task_file_py,
                                         fast=True,
-                                        mode=FileMode(),
+                                        mode=mode,
                                         write_back=WriteBack(1))
     if black_result:
         click.echo(f"Reformatted {filename} with black.")

--- a/src/soorgeon/cli.py
+++ b/src/soorgeon/cli.py
@@ -61,6 +61,9 @@ def refactor(path, log, product_prefix, df_format, single_task, file_format,
     User guide: https://github.com/ploomber/soorgeon/blob/main/doc/guide.md
     """
 
+    # apply black
+    clean_module.basic_clean(path, string_normalization=False)
+
     export.refactor(path,
                     log,
                     product_prefix=product_prefix,


### PR DESCRIPTION
## Describe your changes
1. `clean_mudule.basic_clean(nb_path)` already implements this logic of applying black
2.  So now is also run before `export.refactor(...)` (in cli.py)
3.  I can work on the failing tests. First would like your input, I could be missing something.
## Issue ticket number and link
Closes #84 

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests (when necessary).
- [ ] I have added the right documentation (when needed). Product update? If yes, write one line about this update.
